### PR TITLE
Added pattern to url_escape

### DIFF
--- a/lib/Cloudinary.pm
+++ b/lib/Cloudinary.pm
@@ -347,7 +347,7 @@ sub _api_sign_request {
   my @query;
 
   for my $k (@SIGNATURE_KEYS) {
-    push @query, "$k=" . url_escape $args->{$k} if defined $args->{$k};
+    push @query, "$k=" . url_escape( $args->{$k}, '^A-Za-z0-9\-._~\/' ) if defined $args->{$k};
   }
 
   $query[-1] .= $self->api_secret;

--- a/t/cloudinary.t
+++ b/t/cloudinary.t
@@ -6,7 +6,7 @@ use Mojo::Asset::File;
 use Mojo::IOLoop;
 use Cloudinary;
 
-plan tests => 28;
+plan tests => 29;
 
 # test data from
 # https://cloudinary.com/documentation/upload_images#request_authentication
@@ -17,6 +17,14 @@ my $cloudinary = Cloudinary->new({ api_key => '1234567890', api_secret => 'abcd'
     $cloudinary->_api_sign_request({ timestamp => 1315060510, public_id => 'sample', file => 'foo bar', }),
     'c3470533147774275dd37996cc4d0e68fd03cd4f',
     'signed request'
+  );
+}
+
+{
+  is(
+    $cloudinary->_api_sign_request({ timestamp => 1315060510, public_id => 'sample/sample', file => 'foo bar', }),
+    'ee4e5fc1304c319141776641e32eeb872d8c53d8',
+    'signed request with slash'
   );
 }
 


### PR DESCRIPTION
When passing a "/" in the public_id, I receive signature errors. Cloudinary.pm url_escapes the slash in the id before signing; however, the Cloudinary api may calculate the signature based on the unescaped slash, thereby resulting in unmatched signatures. The Public ID docs do require a URL-safe string, but also allow for slashes to separate elements (simulate directories). The patch is to allow for a slash "/" to be allowed into the safe character set.