### PR TITLE
No need to URL escape parameters in the signature string

### DIFF
--- a/lib/Cloudinary.pm
+++ b/lib/Cloudinary.pm
@@ -2,7 +2,7 @@ package Cloudinary;
 use Mojo::Base -base;
 use File::Basename;
 use Mojo::UserAgent;
-use Mojo::Util qw(sha1_sum url_escape);
+use Mojo::Util qw(sha1_sum);
 use Scalar::Util 'weaken';
 
 our $VERSION = '0.15';
@@ -134,7 +134,7 @@ sub _api_sign_request {
   my @query;
 
   for my $k (@SIGNATURE_KEYS) {
-    push @query, "$k=" . url_escape($args->{$k}, '^A-Za-z0-9\-._~\/') if defined $args->{$k};
+    push @query, "$k=$args->{$k}" if defined $args->{$k};
   }
 
   $query[-1] .= $self->api_secret;

--- a/t/cloudinary.t
+++ b/t/cloudinary.t
@@ -32,6 +32,14 @@ is(
   'signed request with slash'
 );
 
+is(
+  $cloudinary->_api_sign_request(
+    {timestamp => 1315060510, public_id => 'sample', file => 'foo bar', tags => 'foo,bar'}
+  ),
+  'a70b09e115c84bc955b6870bb6d7591a0145b1c5',
+  'signed request - params should not be URL-escaped when creating signature'
+);
+
 $cloudinary->_ua->once(
   start => sub {
     my ($ua, $tx) = @_;


### PR DESCRIPTION
According to the documentation it is not required to URL escape the POST parameters when creating the signing string.

https://cloudinary.com/documentation/upload_images#creating_api_authentication_signatures

Solves https://github.com/jhthorsen/cloudinary/issues/2 and https://github.com/jhthorsen/cloudinary/issues/3