### PR TITLE
Fix URL escaping in signature string

### DIFF
--- a/lib/Cloudinary.pm
+++ b/lib/Cloudinary.pm
@@ -134,7 +134,7 @@ sub _api_sign_request {
   my @query;
 
   for my $k (@SIGNATURE_KEYS) {
-    push @query, "$k=" . url_escape($args->{$k}, '^A-Za-z0-9\-._~\/') if defined $args->{$k};
+    push @query, "$k=" . url_escape($args->{$k}, '^A-Za-z0-9\-._~/') if defined $args->{$k};
   }
 
   $query[-1] .= $self->api_secret;

--- a/lib/Cloudinary.pm
+++ b/lib/Cloudinary.pm
@@ -134,7 +134,9 @@ sub _api_sign_request {
   my @query;
 
   for my $k (@SIGNATURE_KEYS) {
-    push @query, "$k=" . url_escape($args->{$k}, '^A-Za-z0-9\-._~/') if defined $args->{$k};
+    next unless defined $args->{$k};
+    my $v = $k eq 'public_id' ? url_escape($args->{$k}, '^A-Za-z0-9\-._~/') : $args->{$k};
+    push @query, "$k=$v";
   }
 
   $query[-1] .= $self->api_secret;

--- a/t/cloudinary.t
+++ b/t/cloudinary.t
@@ -32,6 +32,14 @@ is(
   'signed request with slash'
 );
 
+is(
+  $cloudinary->_api_sign_request(
+    {timestamp => 1315060510, public_id => 'sample;sample', file => 'foo bar', tags => 'foo;bar'}
+  ),
+  '1e6f96a0722a59b88bd51d190a20c0ba151cdc5d',
+  'signed request - only public_id is URL escaped'
+);
+
 $cloudinary->_ua->once(
   start => sub {
     my ($ua, $tx) = @_;


### PR DESCRIPTION
This PR addresses 2 issues. In Mojolicious 7.38, the functionality of url_escape was changed and it is no longer necessary to escape slashes in the exclusion pattern. This resolves issue https://github.com/jhthorsen/cloudinary/issues/2.

I have also addressed issue https://github.com/jhthorsen/cloudinary/issues/3, since only the Public ID needs to be URL-escaped.

https://cloudinary.com/documentation/upload_images#creating_api_authentication_signatures